### PR TITLE
fix flaky test testFindItemsByNamespace

### DIFF
--- a/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/url/OpenApiPathBuilder.java
+++ b/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/url/OpenApiPathBuilder.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -60,7 +61,7 @@ public class OpenApiPathBuilder {
 
   private OpenApiPathBuilder() {
     this.pathVariable = new HashMap<>();
-    this.params = new HashMap<>();
+    this.params = new LinkedHashMap<>();
   }
 
   public OpenApiPathBuilder envPathVal(String env) {

--- a/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/service/ItemOpenApiServiceTest.java
+++ b/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/service/ItemOpenApiServiceTest.java
@@ -318,8 +318,8 @@ public class ItemOpenApiServiceTest extends AbstractOpenApiServiceTest {
 
     HttpGet get = request.getValue();
 
-    assertEquals(String.format("%s/envs/%s/apps/%s/clusters/%s/namespaces/%s/items?size=%s&page=%s",
-            someBaseUrl, someEnv, someAppId, someCluster, someNamespace, size, page), get.getURI().toString());
+    assertEquals(String.format("%s/envs/%s/apps/%s/clusters/%s/namespaces/%s/items?page=%s&size=%s",
+            someBaseUrl, someEnv, someAppId, someCluster, someNamespace, page, size), get.getURI().toString());
   }
 
   @Test(expected = RuntimeException.class)


### PR DESCRIPTION
## What's the purpose of this PR

This PR aims to fix the following flaky test case:
[com.ctrip.framework.apollo.openapi.client.service.ItemOpenApiServiceTest.testFindItemsByNamespace](https://github.com/ThugJudy/apollo-java/blob/5344bc4f07288842bb850145bcf80a084bd94114/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/service/ItemOpenApiServiceTest.java#L310)

## Which issue(s) this PR fixes:
The test case [com.ctrip.framework.apollo.openapi.client.service.ItemOpenApiServiceTest.testFindItemsByNamespace](https://github.com/ThugJudy/apollo-java/blob/5344bc4f07288842bb850145bcf80a084bd94114/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/service/ItemOpenApiServiceTest.java#L310) fails due to the below assertion:
https://github.com/ThugJudy/apollo-java/blob/5344bc4f07288842bb850145bcf80a084bd94114/apollo-openapi/src/test/java/com/ctrip/framework/apollo/openapi/client/service/ItemOpenApiServiceTest.java#L321-L322

The parameters of the URI if shuffled, can cause flakiness as it is a simple string comparison where the order in which the parameters arrive is not maintained. The flakiness occurs at the following point:
https://github.com/ThugJudy/apollo-java/blob/d8e4352ff8c9e9c6fc37961c49d4b7018b47fc14/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/service/ItemOpenApiService.java#L215-L222

The add params in line 221 and 222, adds the param to a hashMap. As hashmaps do not preserve the order in which the parameters arrive, these params may be shuffled some times causing flakiness. So, I propose using a LinkedHashMap, so that the order in which the params are inserted is preserved and flakiness is resolved.
https://github.com/ThugJudy/apollo-java/blob/d8e4352ff8c9e9c6fc37961c49d4b7018b47fc14/apollo-openapi/src/main/java/com/ctrip/framework/apollo/openapi/client/url/OpenApiPathBuilder.java#L64

I found and confirmed the flaky behavior using an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which shuffles implementations of nondeterminism operations.

## Reproduce
The following command can be used to reproduce assertion failures and verify the fix:

```
mvn -pl main edu.illinois:nondex-maven-plugin:2.1.1:nondex  -Dtest=com.ctrip.framework.apollo.openapi.client.service.ItemOpenApiServiceTest#testFindItemsByNamespace
```

## Test Environment:

Java version "1.8.0_381"
Apache Maven 3.6.3
macOS Venture Version 13.4.1 (22F82)
Please let me know if you have any concerns or questions.

Follow this checklist to help us incorporate your contribution quickly and easily:

- [X] Read the [Contributing Guide](https://github.com/apolloconfig/apollo/blob/master/CONTRIBUTING.md) before making this pull request.
- [X] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [X] Write necessary unit tests to verify the code.
- [X] Run `mvn clean test` to make sure this pull request doesn't break anything.
- [ ] Update the [`CHANGES` log](https://github.com/apolloconfig/apollo-java/blob/master/CHANGES.md).
